### PR TITLE
Issue139

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# EditorConfig.org
+
+root = true
+
+[*]
+indent_size = 4
+indent_style = space

--- a/lib/services/html-parser.js
+++ b/lib/services/html-parser.js
@@ -139,9 +139,10 @@ const TOKEN_BUILDERS = {
                     ? `${attr.prefix}:${attr.name}`
                     : attr.name
                 // https://github.com/ota-meshi/eslint-plugin-lodash-template/issues/139
-                const attrLoc = (key in location.startTag.attrs)
-                    ? location.startTag.attrs[key]
-                    : location.startTag.attrs[key.toLowerCase()] // fix for viewBox
+                const attrLoc =
+                    key in location.startTag.attrs
+                        ? location.startTag.attrs[key]
+                        : location.startTag.attrs[key.toLowerCase()] // fix for viewBox and other camelCase attributes in SVG
                 const attrToken = new HTMLAttribute(
                     html,
                     attrLoc.startOffset,

--- a/lib/services/html-parser.js
+++ b/lib/services/html-parser.js
@@ -138,7 +138,10 @@ const TOKEN_BUILDERS = {
                 const key = attr.prefix
                     ? `${attr.prefix}:${attr.name}`
                     : attr.name
-                const attrLoc = location.startTag.attrs[key]
+                // https://github.com/ota-meshi/eslint-plugin-lodash-template/issues/139
+                const attrLoc = (key in location.startTag.attrs)
+                    ? location.startTag.attrs[key]
+                    : location.startTag.attrs[key.toLowerCase()] // fix for viewBox
                 const attrToken = new HTMLAttribute(
                     html,
                     attrLoc.startOffset,

--- a/tests/lib/rules/attribute-name-casing.js
+++ b/tests/lib/rules/attribute-name-casing.js
@@ -40,6 +40,11 @@ tester.run("attribute-name-casing", rule, {
             filename: "test.html",
             code: '<svg xml:space="preserve"></svg>',
         },
+        {
+            filename: "test-viewbox.html",
+            code: '<svg viewBox="0 0 100 100"></svg>',
+            options: [{ ignore: ["viewBox"] }],
+        },
     ],
 
     invalid: [


### PR DESCRIPTION
This PR also adds an editorconfig file which I added so that my editor would match your indent style by default, but I can remove that if you'd prefer.

My fix also just tries lowercase if the key from the AST doesn't exist, but if this is too broad, I can add a special case just for `viewBox`.  There are other camelCase attributes in SVG, though, so I figured I'd go for broader rather than narrower.

A further option would be to set a list of camelCase SVG attributes and only try lowercase for those attributes.  See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute

See also https://github.com/htmlhint/HTMLHint/issues/28, https://github.com/htmlhint/HTMLHint/issues/183

This could also totally be a bug to open against parse5 instead.

**UPDATE:** I opened a bug with parse5 (https://github.com/inikulin/parse5/issues/318), so if they choose to fix that, this fix will become obsolete.