### PR TITLE
Ignore SVG camelCast attributes by default (fix #140)

### DIFF
--- a/docs/rules/attribute-name-casing.md
+++ b/docs/rules/attribute-name-casing.md
@@ -33,6 +33,7 @@ This rule enforces attribute name casing style (kebab-case).
 {
   "lodash-template/attribute-name-casing": ["error", {
     "ignore": [],
+    "ignoreSvgCamelCaseAttributes": true,
   }]
 }
 ```
@@ -44,6 +45,17 @@ This rule enforces attribute name casing style (kebab-case).
 ```html
 <!-- ✓ GOOD -->
 <div onClick="abc">
+```
+
+</eslint-code-block>
+
+### Examples for this rule with `"ignoreSvgCamelCaseAttributes": true,` (default)
+
+<eslint-code-block fix :rules="{'lodash-template/attribute-name-casing': ['error', {'ignoreSvgCamelCaseAttributes': true}]}">
+
+```html
+<!-- ✓ GOOD -->
+<svg viewBox="0 0 100 100"></svg>
 ```
 
 </eslint-code-block>

--- a/lib/rules/attribute-name-casing.js
+++ b/lib/rules/attribute-name-casing.js
@@ -5,6 +5,75 @@ const casing = require("../utils/casing")
 
 const converter = casing.getConverter("kebab-case")
 
+const DEFAULTS = {
+    ignore: [],
+    ignoreSvgCamelCaseAttributes: true,
+}
+
+const SVG_CAMEL_ATTRS = [
+    "allowReorder",
+    "attributeName",
+    "attributeType",
+    "baseFrequency",
+    "baseProfile",
+    "calcMode",
+    "clipPathUnits",
+    "contentScriptType",
+    "contentStyleType",
+    "diffuseConstant",
+    "edgeMode",
+    "externalResourcesRequired",
+    "filterRes",
+    "filterUnits",
+    "glyphRef",
+    "gradientTransform",
+    "gradientUnits",
+    "kernelMatrix",
+    "kernelUnitLength",
+    "keyPoints",
+    "keySplines",
+    "keyTimes",
+    "lengthAdjust",
+    "limitingConeAngle",
+    "markerHeight",
+    "markerUnits",
+    "markerWidth",
+    "maskContentUnits",
+    "maskUnits",
+    "numOctaves",
+    "pathLength",
+    "patternContentUnits",
+    "patternTransform",
+    "patternUnits",
+    "pointsAtX",
+    "pointsAtY",
+    "pointsAtZ",
+    "preserveAlpha",
+    "preserveAspectRatio",
+    "primitiveUnits",
+    "referrerPolicy",
+    "refX",
+    "refY",
+    "repeatCount",
+    "repeatDur",
+    "requiredExtensions",
+    "requiredFeatures",
+    "specularConstant",
+    "specularExponent",
+    "spreadMethod",
+    "startOffset",
+    "stdDeviation",
+    "stitchTiles",
+    "surfaceScale",
+    "systemLanguage",
+    "tableValues",
+    "targetX",
+    "targetY",
+    "textLength",
+    "viewBox",
+    "viewTarget",
+]
+
 module.exports = {
     meta: {
         docs: {
@@ -22,6 +91,9 @@ module.exports = {
             {
                 type: "object",
                 properties: {
+                    ignoreSvgCamelCaseAttributes: {
+                        type: "boolean",
+                    },
                     ignore: {
                         type: "array",
                         items: {
@@ -48,8 +120,11 @@ module.exports = {
         if (!utils.isHtmlFile(context.getFilename())) {
             return {}
         }
-        const option = context.options[0] || {}
-        const ignore = option.ignore || []
+        const option = Object.assign({}, DEFAULTS, context.options[0] || {})
+        const ignore = []
+            .concat(option.ignore || [])
+            // https://github.com/ota-meshi/eslint-plugin-lodash-template/issues/140
+            .concat(option.ignoreSvgCamelCaseAttributes ? SVG_CAMEL_ATTRS : [])
 
         const microTemplateService = context.parserServices.getMicroTemplateService()
 

--- a/tests/lib/rules/attribute-name-casing.js
+++ b/tests/lib/rules/attribute-name-casing.js
@@ -125,9 +125,7 @@ tester.run("attribute-name-casing", rule, {
             code: '<svg viewBox="0 0 100 100"></svg>',
             output: null,
             options: [{ ignoreSvgCamelCaseAttributes: false }],
-            errors: [
-                "Attribute `viewBox` must be 'kebab-case'."
-            ],
+            errors: ["Attribute `viewBox` must be 'kebab-case'."],
         },
     ],
 })

--- a/tests/lib/rules/attribute-name-casing.js
+++ b/tests/lib/rules/attribute-name-casing.js
@@ -40,6 +40,10 @@ tester.run("attribute-name-casing", rule, {
             filename: "test.html",
             code: '<svg xml:space="preserve"></svg>',
         },
+        {
+            filename: "test-svgcamel.html",
+            code: '<svg viewBox="0 0 100 100"></svg>',
+        },
     ],
 
     invalid: [
@@ -114,6 +118,15 @@ tester.run("attribute-name-casing", rule, {
                 "Attribute `DATA-ID` must be 'kebab-case'.",
                 "Attribute `ARIA-TEST` must be 'kebab-case'.",
                 "Attribute `MY-PROP` must be 'kebab-case'.",
+            ],
+        },
+        {
+            filename: "test-svgcamel.html",
+            code: '<svg viewBox="0 0 100 100"></svg>',
+            output: null,
+            options: [{ ignoreSvgCamelCaseAttributes: false }],
+            errors: [
+                "Attribute `viewBox` must be 'kebab-case'."
             ],
         },
     ],


### PR DESCRIPTION
This adds an option to ignore them as a group (default true) so that customizing the `ignore: []` option in the eslintrc won't cause the rule to stop ignoring all these attributes

### The tests won't pass until #141 is merged (or #139 is fixed some other way)